### PR TITLE
Make tagEvent call the one without CLV increase if there is none

### DIFF
--- a/LocalyticsPlugin/Assets/Localytics/Localytics.cs
+++ b/LocalyticsPlugin/Assets/Localytics/Localytics.cs
@@ -648,7 +648,10 @@ namespace LocalyticsUnity {
 		public static void TagEvent(string eventName, Dictionary<string, string> attributes = null, long customerValueIncrease = 0)
 		{
 			#if UNITY_ANDROID
-			LocalyticsClass.CallStatic("tagEvent", eventName, DictionaryToMap(attributes), customerValueIncrease);
+			if (customerValueIncrease == 0)
+				LocalyticsClass.CallStatic("tagEvent", eventName, DictionaryToMap(attributes));
+			else
+				LocalyticsClass.CallStatic("tagEvent", eventName, DictionaryToMap(attributes), customerValueIncrease);
 			#elif UNITY_IOS
 			string values = "";
 			if (attributes != null)

--- a/LocalyticsPlugin/Assets/Plugins/iOS/LocalyticsUnity.mm
+++ b/LocalyticsPlugin/Assets/Plugins/iOS/LocalyticsUnity.mm
@@ -462,7 +462,10 @@ extern "C"
     
     void _tagEvent(const char* eventName, const char* attributes, long customerValueIncrease)
     {
-        [Localytics tagEvent:LLCreateNSString(eventName) attributes:LLMakeNSDictionary(attributes) customerValueIncrease:[NSNumber numberWithLong:customerValueIncrease]];
+        if (customerValueIncrease == 0)
+            [Localytics tagEvent:LLCreateNSString(eventName) attributes:LLMakeNSDictionary(attributes)];
+        else
+            [Localytics tagEvent:LLCreateNSString(eventName) attributes:LLMakeNSDictionary(attributes) customerValueIncrease:[NSNumber numberWithLong:customerValueIncrease]];
     }
     
     void _tagScreen(const char* screenName)


### PR DESCRIPTION
Before this change, all events get tracked with a 0 CLV increase, causing all users to appear as a paid user regardless of whether they've spent any money, and all events to be tracked as transactions.
